### PR TITLE
Prevent the output of illogical warnings

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -72,7 +72,7 @@ log-warning () {
 
 # Check for missing encouraged arguments
 if ! $SUPPRESS_WARNINGS; then
-  if $ENABLE_CHAT_MESSAGES && [[ $SCREEN_NAME == "" ]]; then
+  if [[ $SCREEN_NAME == "" ]]; then
     log-warning "Minecraft screen name not specified (use -s)"
   fi
 fi

--- a/backup.sh
+++ b/backup.sh
@@ -72,7 +72,7 @@ log-warning () {
 
 # Check for missing encouraged arguments
 if ! $SUPPRESS_WARNINGS; then
-  if [[ $SCREEN_NAME == "" ]]; then
+  if $ENABLE_CHAT_MESSAGES && [[ $SCREEN_NAME == "" ]]; then
     log-warning "Minecraft screen name not specified (use -s)"
   fi
 fi
@@ -194,7 +194,7 @@ delete-thinning () {
 
   # Warn if $MAX_BACKUPS does not have enough room for all the blocks
   TOTAL_BLOCK_SIZE=$(array-sum ${BLOCK_SIZES[@]})
-  if [[ $TOTAL_BLOCK_SIZE -gt $MAX_BACKUPS ]]; then
+  if [[  $MAX_BACKUPS != -1 ]] && [[ $TOTAL_BLOCK_SIZE -gt $MAX_BACKUPS ]]; then
     if ! $SUPPRESS_WARNINGS; then
       log-warning "MAX_BACKUPS ($MAX_BACKUPS) is smaller than TOTAL_BLOCK_SIZE ($TOTAL_BLOCK_SIZE)"
     fi


### PR DESCRIPTION
I have been using the script a lot, thus thank you @nicolaschan.

**This pull request fixes warnings in cases where they did not make much sense:**

 - `WARNING: Minecraft screen name not specified (use -s)`
   Even when `ENABLE_CHAT_MESSAGES` is false - you don't want to _tell players in Minecraft chat about backup status_, thus it makes sense to not provide a screen name.

- `WARNING: MAX_BACKUPS (-1) is smaller than TOTAL_BLOCK_SIZE (70)`
  If the `MAX_BACKUPS` is set to infinite (-1) it should not output this.


**What about `SUPPRESS_WARNINGS`?**

This functionality is kept working as expected - and it remains unchanged.
