### PR TITLE
spigot/paper worldnaming compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cd restored-world
 tar -xzvf /path/to/backups/2019-04-09_02-15-01.tar.gz
 ```
 
-Then you can move your restored world (`restored-world` in this case) to your Minecraft server folder and rename it (usually called `world`) so the Minecraft server uses it.
+The restored worlds should be inside the `restored-world` directory, possibly nested under the parent directories. Then you can move your restored world to your Minecraft server folder under the proper name and path so the Minecraft server uses it.
 
 ### With `restic`
 Use [`restic restore`](https://restic.readthedocs.io/en/latest/050_restore.html) to restore from backup.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Command line options:
 -e    Compression file extension, exclude leading "." (default: gz)
 -f    Output file name (default is the timestamp)
 -h    Shows this help text
--i    Input directory (path to world folder)
+-i    Input directory (path to world folder, use -i once for each world)
 -l    Compression level (default: 3)
 -m    Maximum backups to keep, use -1 for unlimited (default: 128)
 -o    Output directory

--- a/backup.sh
+++ b/backup.sh
@@ -41,7 +41,7 @@ debug-log () {
   fi
 }
 
-while getopts 'a:cd:e:f:hi:l:m:o:p:qr:s:t:u:vw:x:' FLAG; do
+while getopts 'a:cd:e:f:hi:l:m:o:p:qr:s:t:u:vw:x' FLAG; do
   case $FLAG in
     a) COMPRESSION_ALGORITHM=$OPTARG ;;
     c) ENABLE_CHAT_MESSAGES=true ;;
@@ -482,9 +482,9 @@ do-backup () {
   # set bukkit world paths if this is a bukkit server
   if "$BUKKIT"; then
     WORLD_PARENT_DIR=$(dirname "$SERVER_WORLD")
-
+    SERVER_WORLD=$(realpath "$SERVER_WORLD")
     # overwrite SERVER_WORLD so that restic gets all 3 dirs
-    SERVER_WORLD="$SERVER_WORLD"\ "$SERVER_WORLD"_nether\ "$SERVER_WORLD"_the_end
+    SERVER_WORLD="$SERVER_WORLD/"\ "$SERVER_WORLD"_nether/\ "$SERVER_WORLD"_the_end/
     TAR_ARGS=$(basename -a "$SERVER_WORLD")
   else
     # no bukkit--retain previous functionality
@@ -506,10 +506,10 @@ do-backup () {
 
     case $COMPRESSION_ALGORITHM in
       # No compression
-      "") tar -cf "$ARCHIVE_PATH" -C "$WORLD_PARENT_DIR" "$TAR_ARGS"
+      "") tar -cf "$ARCHIVE_PATH" -C "$WORLD_PARENT_DIR" $TAR_ARGS
         ;;
       # With compression
-      *) tar -cf - -C "$WORLD_PARENT_DIR" "$TAR_ARGS" | $COMPRESSION_ALGORITHM -cv -"$COMPRESSION_LEVEL" - > "$ARCHIVE_PATH" 2>> /dev/null
+      *) tar -cf - -C "$WORLD_PARENT_DIR" $TAR_ARGS | $COMPRESSION_ALGORITHM -cv -"$COMPRESSION_LEVEL" - > "$ARCHIVE_PATH" 2>> /dev/null
         ;;
     esac
     EXIT_CODES=("${PIPESTATUS[@]}")
@@ -531,7 +531,7 @@ do-backup () {
 
   if [[ "$RESTIC_REPO" != "" ]]; then
     RESTIC_TIMESTAMP="${TIMESTAMP:0:10} ${TIMESTAMP:11:2}:${TIMESTAMP:14:2}:${TIMESTAMP:17:2}"
-    restic backup -r "$RESTIC_REPO" "$SERVER_WORLD" --time "$RESTIC_TIMESTAMP" "$QUIET"
+    restic backup -r "$RESTIC_REPO" $SERVER_WORLD --time "$RESTIC_TIMESTAMP" "$QUIET"
     ARCHIVE_EXIT_CODE=$?
     if [ "$ARCHIVE_EXIT_CODE" -eq 3 ]; then
       log-warning "Incomplete snapshot taken (some files could not be read)"

--- a/backup.sh
+++ b/backup.sh
@@ -485,7 +485,7 @@ do-backup () {
     WORLDS_NAME=$(realpath "$SERVER_WORLD")
     # overwrite SERVER_WORLD so that restic gets all 3 dirs
     WORLDS_NAME="$WORLDS_NAME/"\ "$WORLDS_NAME"_nether/\ "$WORLDS_NAME"_the_end/
-    TAR_ARGS=$(basename -a "$SERVER_WORLD")
+    TAR_ARGS=$(basename -a "$WORLDS_NAME")
   else
     # no bukkit--retain previous functionality
     WORLD_PARENT_DIR="$SERVER_WORLD"

--- a/backup.sh
+++ b/backup.sh
@@ -485,7 +485,7 @@ do-backup () {
     WORLDS_NAME=$(realpath "$SERVER_WORLD")
     # overwrite SERVER_WORLD so that restic gets all 3 dirs
     WORLDS_NAME="$WORLDS_NAME/"\ "$WORLDS_NAME"_nether/\ "$WORLDS_NAME"_the_end/
-    TAR_ARGS=$(basename -a "$WORLDS_NAME")
+    TAR_ARGS=$(basename -a $WORLDS_NAME)
   else
     # no bukkit--retain previous functionality
     WORLD_PARENT_DIR="$SERVER_WORLD"

--- a/backup.sh
+++ b/backup.sh
@@ -55,7 +55,7 @@ while getopts 'a:cd:e:f:hi:l:m:o:p:qr:s:t:u:vw:x' FLAG; do
        echo "-e    Compression file extension, exclude leading \".\" (default: gz)"
        echo "-f    Output file name (default is the timestamp)"
        echo "-h    Shows this help text"
-       echo "-i    Input directory (path to world folder)"
+       echo "-i    Input directory (path to world folder, use -i once for each world)"
        echo "-l    Compression level (default: 3)"
        echo "-m    Maximum backups to keep, use -1 for unlimited (default: 128)"
        echo "-o    Output directory"

--- a/backup.sh
+++ b/backup.sh
@@ -41,7 +41,7 @@ debug-log () {
   fi
 }
 
-while getopts 'a:cd:e:f:hi:l:m:o:p:qr:s:t:u:vw:' FLAG; do
+while getopts 'a:cd:e:f:hi:l:m:o:p:qr:s:t:u:vw:x:' FLAG; do
   case $FLAG in
     a) COMPRESSION_ALGORITHM=$OPTARG ;;
     c) ENABLE_CHAT_MESSAGES=true ;;

--- a/backup.sh
+++ b/backup.sh
@@ -482,13 +482,14 @@ do-backup () {
   # set bukkit world paths if this is a bukkit server
   if "$BUKKIT"; then
     WORLD_PARENT_DIR=$(dirname "$SERVER_WORLD")
-    SERVER_WORLD=$(realpath "$SERVER_WORLD")
+    WORLDS_NAME=$(realpath "$SERVER_WORLD")
     # overwrite SERVER_WORLD so that restic gets all 3 dirs
-    SERVER_WORLD="$SERVER_WORLD/"\ "$SERVER_WORLD"_nether/\ "$SERVER_WORLD"_the_end/
+    WORLDS_NAME="$WORLDS_NAME/"\ "$WORLDS_NAME"_nether/\ "$WORLDS_NAME"_the_end/
     TAR_ARGS=$(basename -a "$SERVER_WORLD")
   else
     # no bukkit--retain previous functionality
     WORLD_PARENT_DIR="$SERVER_WORLD"
+    WORLDS_NAME="$SERVER_WORLD"
     TAR_ARGS="."
   fi
   # Notify players of start
@@ -531,7 +532,7 @@ do-backup () {
 
   if [[ "$RESTIC_REPO" != "" ]]; then
     RESTIC_TIMESTAMP="${TIMESTAMP:0:10} ${TIMESTAMP:11:2}:${TIMESTAMP:14:2}:${TIMESTAMP:17:2}"
-    restic backup -r "$RESTIC_REPO" $SERVER_WORLD --time "$RESTIC_TIMESTAMP" "$QUIET"
+    restic backup -r "$RESTIC_REPO" $WORLDS_NAME --time "$RESTIC_TIMESTAMP" "$QUIET"
     ARCHIVE_EXIT_CODE=$?
     if [ "$ARCHIVE_EXIT_CODE" -eq 3 ]; then
       log-warning "Incomplete snapshot taken (some files could not be read)"


### PR DESCRIPTION
This commit is a spigot/paper-specific implementation of multiple-world backup, as these "worlds" are merely just spilt up dimensions from what would be a normal minecraft world. I took the route of adding a conditional flag, and then modifying the arguments that are sent to tar or restic based on whether the server is vanilla or spigot/paper.