### PR TITLE
Add rclone to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 LABEL org.opencontainers.image.source=https://github.com/nicolaschan/minecraft-backup
 
-RUN apk add bash coreutils xxd restic util-linux openssh
+RUN apk add bash coreutils xxd restic util-linux openssh rclone
 
 WORKDIR /code
 COPY ./backup.sh .


### PR DESCRIPTION
Allows the `rclone` `restic` backend to be used with the container.