### PR TITLE
Feature/docker minecraft support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ docker run \
   -v /home/user/server/world:/mnt/server \
   -v /mnt/storage/backups:/mnt/backups \
   ghcr.io/nicolaschan/minecraft-backup -c -i /mnt/server -o /mnt/backups -s server-host:25575:secret -w rcon
+  
+# Using itzg/docker-minecraft-server container and rcon cli
+./backup.sh -c -i /home/user/server/world -o /mnt/storage/backups -s container-name -w docker-rcon
 ```
 
 This will show chat messages (`-c`) and save a backup of `/home/user/server/world` into `/mnt/storage/backups` using the default thinning deletion policy for old backups.
@@ -64,7 +67,7 @@ Command line options:
 -p    Prefix that shows in Minecraft chat (default: Backup)
 -q    Suppress warnings
 -r    Restic repo name (if using restic)
--s    Screen name, tmux session name, or hostname:port:password for RCON
+-s    Screen name, tmux session name, hostname:port:password for RCON or [container name](https://github.com/itzg/docker-minecraft-server) for docker-rcon
 -t    Enable lock file (lock file not used by default)
 -u    Lock file timeout seconds (empty = unlimited)
 -v    Verbose mode

--- a/backup.sh
+++ b/backup.sh
@@ -268,7 +268,6 @@ execute-command () {
         ;;
       "docker-rcon") docker exec "$SCREEN_NAME" rcon-cli "$COMMAND"
         ;;
-
     esac
   fi
 }

--- a/backup.sh
+++ b/backup.sh
@@ -266,6 +266,9 @@ execute-command () {
         ;;
       "RCON"|"rcon") rcon-command "$SCREEN_NAME" "$COMMAND"
         ;;
+      "docker-rcon") docker exec "$SCREEN_NAME" rcon-cli "$COMMAND"
+        ;;
+
     esac
   fi
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -379,6 +379,20 @@ test-rcon-interface-not-running () {
   assertContains "$OUTPUT" "Could not connect"
 }
 
+test-docker-rcon () {
+  CONTAINER="$(docker run -d -e EULA=TRUE docker.io/itzg/minecraft-server)"
+  while ! docker exec "$CONTAINER" grep 'RCON running on 0.0.0.0:25575' /data/logs/latest.log; do
+    sleep 0.1
+  done
+  TIMESTAMP="$(date +%F_%H-%M-%S --date="2021-01-01")"
+  ./backup.sh -w docker-rcon -i "$TEST_TMP/server/world" -o "$TEST_TMP/backups" -s "$CONTAINER" -f "$TIMESTAMP"
+  OUTPUT="$(docker exec "$CONTAINER" cat /data/logs/latest.log)"
+  docker rm -f "$CONTAINER"
+  assertContains "$OUTPUT" "[Rcon: Automatic saving is now disabled]"
+  assertContains "$OUTPUT" "[Rcon: Automatic saving is now enabled]"
+  assertContains "$OUTPUT" "[Rcon: Saved the game]"
+}
+
 test-sequential-delete () {
   for i in $(seq 0 20); do
     TIMESTAMP="$(date +%F_%H-%M-%S --date="2021-01-01 +$i hour")"


### PR DESCRIPTION
This patch adds support for the https://github.com/itzg/docker-minecraft-server docker image when using bin mounts.

Commands are executed via the integrated rcon-cli. The screen name is used as the container name